### PR TITLE
Numerical issues for Type3 conflicts

### DIFF
--- a/PNlib/Blocks/activationDis.mo
+++ b/PNlib/Blocks/activationDis.mo
@@ -36,7 +36,7 @@ algorithm
         active:=false;
       end if;
     else  //continuous
-      if (arcType[i]==1 or normalArc[i]==2) and not (tIn[i]-arcWeightIn[i]-minTokens[i] >= -Constants.eps) then
+      if (arcType[i]==1 or normalArc[i]==2) and not (tIn[i]-arcWeightIn[i]-minTokens[i] >= -Constants.almost_eps) then
         active:=false;
       elseif arcType[i]==2 and not (tIn[i] > testValue[i]) then
         active:=false;
@@ -52,7 +52,7 @@ algorithm
        active:=false;
       end if;
    else  //continuous
-      if not (tOut[i]+arcWeightOut[i]-maxTokens[i] <= Constants.eps) then
+      if not (tOut[i]+arcWeightOut[i]-maxTokens[i] <= Constants.almost_eps) then
        active:=false;
       end if;
    end if;

--- a/PNlib/Blocks/enablingInCon.mo
+++ b/PNlib/Blocks/enablingInCon.mo
@@ -27,11 +27,13 @@ protected
     "sum of the enabling probabilities of the active input transitions";
   Boolean endWhile;
 algorithm
+  TEin:=fill(false, nIn);
+
   when delayPassed then
     if nIn>0 then
       disTAin:=TAein and disTransition;
       arcWeightSum:=Functions.OddsAndEnds.conditionalSum(arcWeight,disTAin);  //arc weight sum of all active input transitions which are already enabled by their input places
-      if t + arcWeightSum <= maxMarks or Functions.OddsAndEnds.isEqual(arcWeightSum, 0.0) then  //Place has no actual conflict; all active input transitions are enabled
+      if t + arcWeightSum -maxMarks <= Constants.almost_eps or Functions.OddsAndEnds.isEqual(arcWeightSum, 0.0) then  //Place has no actual conflict; all active input transitions are enabled
         TEin:=TAein;
       else                          //Place has an actual conflict
         TEin:=TAein and not disTransition;
@@ -66,16 +68,16 @@ algorithm
             endWhile:=false;
             k:=1;
             while k<=nremTAin and not endWhile loop
-                if randNum <= cumEnablingProb[k] then
-                   posTE:=remTAin[k];
-                   endWhile:=true;
-                else
-                  k:=k + 1;
-                end if;
+              if randNum <= cumEnablingProb[k] then
+                posTE:=remTAin[k];
+                endWhile:=true;
+              else
+                k:=k + 1;
+              end if;
             end while;
-            if t+arcWeightSum + arcWeight[posTE] <= maxMarks or Functions.OddsAndEnds.isEqual(arcWeight[i], 0.0) then
-               arcWeightSum:=arcWeightSum + arcWeight[posTE];
-               TEin[posTE]:=true;
+            if t+arcWeightSum + arcWeight[posTE] -maxMarks <= Constants.almost_eps or Functions.OddsAndEnds.isEqual(arcWeight[i], 0.0) then
+              arcWeightSum:=arcWeightSum + arcWeight[posTE];
+              TEin[posTE]:=true;
             end if;
             nremTAin:=nremTAin - 1;
             if nremTAin > 0 then
@@ -85,17 +87,16 @@ algorithm
               if sumEnablingProbTAin>0 then
                 cumEnablingProb[1]:=enablingProb[remTAin[1]]/sumEnablingProbTAin;
                 for j in 2:nremTAin loop
-                    cumEnablingProb[j]:=cumEnablingProb[j-1]+enablingProb[remTAin[j]]/sumEnablingProbTAin;
+                  cumEnablingProb[j]:=cumEnablingProb[j-1]+enablingProb[remTAin[j]]/sumEnablingProbTAin;
                 end for;
               else
-                  cumEnablingProb[1:nremTAin]:=fill(1/nremTAin, nremTAin);
+                cumEnablingProb[1:nremTAin]:=fill(1/nremTAin, nremTAin);
               end if;
             end if;
-        end for;
-       end if;
+          end for;
+        end if;
       end if;
-   else
-      TEin:=fill(false, nIn);
+    else
       disTAin:=fill(false, nIn);
       remTAin:=fill(0, nIn);
       cumEnablingProb:=fill(0.0, nIn);

--- a/PNlib/Blocks/enablingOutCon.mo
+++ b/PNlib/Blocks/enablingOutCon.mo
@@ -3,7 +3,7 @@ block enablingOutCon
   "enabling process of output transitions (continuous places)"
   parameter input Integer nOut "number of output transitions";
   input Real arcWeight[:] "arc weights of output transitions";
-  input Real t_ "current marks";
+  input Real t "current marks";
   input Real minMarks "minimum capacity";
   input Boolean TAout[:] "active output transitions with passed delay";
   input Integer enablingType "resolution of actual conflicts";
@@ -12,8 +12,6 @@ block enablingOutCon
   input Boolean delayPassed "Does any delayPassed of a output transition";
   output Boolean TEout_[nOut] "enabled output transitions";
 protected
-  Real t=t_+Constants.eps
-    "numeric to realize the correct simulation of some specific hybrid petri nets";
   Boolean TEout[nOut] "enabled output transitions";
   Boolean disTAout[nOut] "discret active output transitions";
   Integer remTAout[nOut] "remaining active output transitions";
@@ -29,12 +27,14 @@ protected
     "sum of the enabling probabilities of the active output transitions";
   Boolean endWhile;
 algorithm
+  TEout:=fill(false, nOut);
+
   when delayPassed then
     if nOut>0 then
     disTAout:=TAout and disTransition;
     arcWeightSum := Functions.OddsAndEnds.conditionalSum(arcWeight, disTAout);
                                                                    //arc weight sum of all active output transitions
-    if t - arcWeightSum >= minMarks or Functions.OddsAndEnds.isEqual(arcWeightSum, 0.0) then  //Place has no actual conflict; all active output transitions are enabled
+    if t - arcWeightSum -minMarks >= -Constants.almost_eps or Functions.OddsAndEnds.isEqual(arcWeightSum, 0.0) then  //Place has no actual conflict; all active output transitions are enabled
       TEout:=TAout;
     else                          //Place has an actual conflict;
       TEout:=TAout and not disTransition;
@@ -76,7 +76,7 @@ algorithm
                 k:=k + 1;
               end if;
           end while;
-          if (t-(arcWeightSum + arcWeight[posTE]) >= minMarks) or  Functions.OddsAndEnds.isEqual(arcWeight[i], 0.0) then
+          if (t-(arcWeightSum + arcWeight[posTE])-minMarks >= -Constants.almost_eps) or  Functions.OddsAndEnds.isEqual(arcWeight[i], 0.0) then
              arcWeightSum:=arcWeightSum + arcWeight[posTE];
              TEout[posTE]:=true;
           end if;
@@ -98,7 +98,6 @@ algorithm
        end if;
       end if;
     else
-      TEout:=fill(false, nOut);
       disTAout:=fill(false, nOut);
       remTAout:=fill(0, nOut);
       cumEnablingProb:=fill(0.0, nOut);

--- a/PNlib/Constants/package.mo
+++ b/PNlib/Constants/package.mo
@@ -5,6 +5,7 @@ package Constants "contains constants which are used in the Petri net component 
   constant Integer Integer_inf = 1073741823
   "Biggest Integer number such that Integer_inf and -Integer_inf are representable on the machine";
   constant Real eps=1.e-15 "Biggest number such that 1.0 + eps = 1.0";
+  constant Real almost_eps=1.e-9;
   constant Real rand_max = Functions.Random.randomMax()
   "the largest value the rand function can return";
 end Constants;

--- a/PNlib/Constants/package.order
+++ b/PNlib/Constants/package.order
@@ -1,4 +1,5 @@
 inf
 Integer_inf
 eps
+almost_eps
 rand_max

--- a/PNlib/PC.mo
+++ b/PNlib/PC.mo
@@ -57,7 +57,7 @@ protected
   //****BLOCKS BEGIN****// since no events are generated within functions!!!
   //enabling discrete transitions
   Blocks.enablingInCon enableIn(active=activeIn,delayPassed=delayPassedIn.anytrue,nIn=nIn,arcWeight=arcWeightIn, t=t_, maxMarks=maxMarks,TAein=enabledByInPlaces,enablingType=enablingType, enablingProb=enablingProbIn,disTransition=disTransitionIn);
-  Blocks.enablingOutCon enableOut(delayPassed=delayPassedOut.anytrue, nOut=nOut,arcWeight=arcWeightOut, t_=t_, minMarks=minMarks, TAout=activeOut, enablingType=enablingType, enablingProb=enablingProbOut,disTransition=disTransitionOut);
+  Blocks.enablingOutCon enableOut(delayPassed=delayPassedOut.anytrue, nOut=nOut,arcWeight=arcWeightOut, t=t_, minMarks=minMarks, TAout=activeOut, enablingType=enablingType, enablingProb=enablingProbOut,disTransition=disTransitionOut);
   //Does any delay passed of a connected transition?
   Blocks.anyTrue delayPassedOut(vec=activeOut and disTransitionOut);
   Blocks.anyTrue delayPassedIn(vec=activeIn and disTransitionIn);


### PR DESCRIPTION
OpenModelica misses events in case of Type3 conflicts. This is due to numerical tolerances within event detection. The same models work fine with Dymola. However, I'm not sure if this is a library or tool issue.