### PR TITLE
Fixing Typ 3 Conflict

### DIFF
--- a/PNlib/Blocks/activationCon.mo
+++ b/PNlib/Blocks/activationCon.mo
@@ -52,13 +52,13 @@ algorithm
         end if;
       end if;
       if arcType[i]==2 then //test arc
-        if tIn[i] <= testValue[i] then
+        if tIn[i] - testValue[i] <= Constants.almost_eps then
           active := false;
         end if;
-        if tIn[i] > testValue[i] and fed[i] and normalArc[i]==2 then  //weakly input active??
+        if tIn[i] - testValue[i] > Constants.almost_eps and fed[i] and normalArc[i]==2 then  //weakly input active??
           weaklyInputActiveVec[i] := true;
         end if;
-      elseif arcType[i]==3 and (tIn[i] >= testValue[i]) then  //inhibitor arc
+      elseif arcType[i]==3 and (tIn[i] - testValue[i] >= -Constants.almost_eps) then  //inhibitor arc
         active := false;
       end if;
     end if;

--- a/PNlib/Examples/ConTest/Conflict.mo
+++ b/PNlib/Examples/ConTest/Conflict.mo
@@ -28,5 +28,5 @@ equation
   connect(P3.inTransition[1], T3.outPlaces[1]) annotation(Line(points={{49.2,
           -20}, {34.8, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-40, -40},
-            {80, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {80, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end Conflict;

--- a/PNlib/Examples/ConTest/ConflictLoop.mo
+++ b/PNlib/Examples/ConTest/ConflictLoop.mo
@@ -32,5 +32,5 @@ equation
   connect(P3.outTransition[1], T1.inPlaces[2]) annotation(Line(points={{50.8,
           -20}, {60, -20}, {60, -40}, {-60, -40}, {-60, 0.5}, {-54.8, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-80, -60},
-            {80, 80}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {80, 80}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end ConflictLoop;

--- a/PNlib/Examples/ConTest/LoopAndArcweight.mo
+++ b/PNlib/Examples/ConTest/LoopAndArcweight.mo
@@ -18,5 +18,5 @@ equation
   connect(P2.inTransition[1], T1.outPlaces[2]) annotation(Line(points={{20, 19.2},
           {20, -0.5}, {4.8, -0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-40, -40},
-            {40, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {40, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end LoopAndArcweight;

--- a/PNlib/Examples/ConTest/PCtoTC.mo
+++ b/PNlib/Examples/ConTest/PCtoTC.mo
@@ -12,5 +12,5 @@ equation
   connect(P1.outTransition[1], T1.inPlaces[1]) annotation(Line(points={{10.8, 0},
           {25.2, 0}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-40, -40},
-            {40, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {40, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end PCtoTC;

--- a/PNlib/Examples/ConTest/SinglePC.mo
+++ b/PNlib/Examples/ConTest/SinglePC.mo
@@ -4,5 +4,5 @@ model SinglePC
 
   PNlib.PC P1 annotation(Placement(visible = true, transformation(origin = {0, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   inner PNlib.Settings settings annotation(Placement(visible = true, transformation(origin={30, 30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  annotation(Diagram(coordinateSystem(extent={{-40, -40}, {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime=0.0, StopTime=1.0));
+  annotation(Diagram(coordinateSystem(extent={{-40, -40}, {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime=0.0, StopTime=1.0, Tolerance = 1e-6));
 end SinglePC;

--- a/PNlib/Examples/ConTest/SingleTC.mo
+++ b/PNlib/Examples/ConTest/SingleTC.mo
@@ -4,5 +4,5 @@ model SingleTC
 
   PNlib.TC T1 annotation(Placement(visible = true, transformation(origin = {0, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   inner PNlib.Settings settings annotation(Placement(visible = true, transformation(origin={30, 30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
-  annotation(Diagram(coordinateSystem(extent={{-40, -40}, {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime=0.0, StopTime=1.0));
+  annotation(Diagram(coordinateSystem(extent={{-40, -40}, {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime=0.0, StopTime=1.0, Tolerance = 1e-6));
 end SingleTC;

--- a/PNlib/Examples/ConTest/Speed.mo
+++ b/PNlib/Examples/ConTest/Speed.mo
@@ -24,5 +24,5 @@ equation
   connect(T3.outPlaces[1], P2.inTransition[1]) annotation(Line(points={{34.8, 0},
           {49.2, 0}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-40, -40},
-            {80, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {80, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end Speed;

--- a/PNlib/Examples/ConTest/TCtoPC.mo
+++ b/PNlib/Examples/ConTest/TCtoPC.mo
@@ -12,5 +12,5 @@ equation
   connect(T1.outPlaces[1], P1.inTransition[1]) annotation(Line(points={{-25.2, 0},
           {-10.8, 0}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-40, -40},
-            {40, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {40, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end TCtoPC;

--- a/PNlib/Examples/ConTest/ZeroArcWeight.mo
+++ b/PNlib/Examples/ConTest/ZeroArcWeight.mo
@@ -23,5 +23,5 @@ equation
   connect(T1.outPlaces[1], P3.inTransition[1])
     annotation(Line(points={{4.8, 0}, {29.2, 0}}, color={0, 0, 0}));
   annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -40},
-            {60, 40}})), experiment(StartTime=0.0, StopTime=12.0));
+            {60, 40}})), experiment(StartTime=0.0, StopTime=12.0, Tolerance = 1e-6));
 end ZeroArcWeight;

--- a/PNlib/Examples/ConTest/ZeroPlace.mo
+++ b/PNlib/Examples/ConTest/ZeroPlace.mo
@@ -20,5 +20,5 @@ equation
   connect(T2.outPlaces[1], P2.inTransition[1]) annotation(Line(points={{14.8, 0},
           {29.2, 0}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-60, -20},
-            {60, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {60, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end ZeroPlace;

--- a/PNlib/Examples/DisTest/ConflictPrio.mo
+++ b/PNlib/Examples/DisTest/ConflictPrio.mo
@@ -27,5 +27,5 @@ equation
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points={{14.8, -20},
           {29.2, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-60, -40},
-            {60, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {60, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end ConflictPrio;

--- a/PNlib/Examples/DisTest/ConflictProb.mo
+++ b/PNlib/Examples/DisTest/ConflictProb.mo
@@ -32,6 +32,6 @@ equation
           {-0.4, -20}, {-0.4, 0.5}, {-9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points={{14.8, -20},
           {29.2, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(experiment(StartTime=0.0, StopTime=10.0),
+  annotation(experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6),
     Diagram(coordinateSystem(extent={{-60, -40}, {60, 40}})));
 end ConflictProb;

--- a/PNlib/Examples/DisTest/DisLoopAndArcweight.mo
+++ b/PNlib/Examples/DisTest/DisLoopAndArcweight.mo
@@ -14,5 +14,5 @@ equation
   connect(T1.outPlaces[1], P1.inTransition[1]) annotation(Line(points={{-6.8, 20},
           {-20, 20}, {-20, -20}, {-10.8, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-40, -40},
-            {40, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {40, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end DisLoopAndArcweight;

--- a/PNlib/Examples/DisTest/EightConflictProb.mo
+++ b/PNlib/Examples/DisTest/EightConflictProb.mo
@@ -37,5 +37,5 @@ equation
   connect(T8.inPlaces[1], P1.outTransition[8]) annotation(Line(points={{5.2, -20},
           {-0.4, -20}, {-0.4, 0.875}, {-29.2, 0.875}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-60, -60},
-            {60, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {60, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end EightConflictProb;

--- a/PNlib/Examples/DisTest/InputConflictPrio.mo
+++ b/PNlib/Examples/DisTest/InputConflictPrio.mo
@@ -28,5 +28,5 @@ equation
   connect(T1.inPlaces[1], P1.outTransition[1]) annotation(Line(points={{45.2, 0},
           {30.8, 0}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-60, -40},
-            {60, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {60, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end InputConflictPrio;

--- a/PNlib/Examples/DisTest/InputConflictProb.mo
+++ b/PNlib/Examples/DisTest/InputConflictProb.mo
@@ -33,6 +33,6 @@ equation
           {0, -20}, {0, 0.5}, {9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T1.inPlaces[1], P1.outTransition[1]) annotation(Line(points={{45.2, 0},
           {30.8, 0}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(experiment(StartTime=0.0, StopTime=10.0),
+  annotation(experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6),
     Diagram(coordinateSystem(extent={{-60, -40}, {60, 40}})));
 end InputConflictProb;

--- a/PNlib/Examples/DisTest/OutputConflictPrio.mo
+++ b/PNlib/Examples/DisTest/OutputConflictPrio.mo
@@ -26,6 +26,6 @@ equation
           {-0.4, -20}, {-0.4, 0.5}, {-9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points={{14.8, -20},
           {29.2, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(experiment(StartTime=0.0, StopTime=10.0),
+  annotation(experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6),
     Diagram(coordinateSystem(extent={{-60, -40}, {60, 40}})));
 end OutputConflictPrio;

--- a/PNlib/Examples/DisTest/OutputConflictProb.mo
+++ b/PNlib/Examples/DisTest/OutputConflictProb.mo
@@ -32,6 +32,6 @@ equation
           {-0.4, -20}, {-0.4, 0.5}, {-9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points={{14.8, -20},
           {29.2, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(experiment(StartTime=0.0, StopTime=10.0),
+  annotation(experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6),
     Diagram(coordinateSystem(extent={{-60, -40}, {60, 40}})));
 end OutputConflictProb;

--- a/PNlib/Examples/DisTest/PDtoTD.mo
+++ b/PNlib/Examples/DisTest/PDtoTD.mo
@@ -12,5 +12,5 @@ equation
   connect(T1.inPlaces[1], P1.outTransition[1]) annotation(Line(points={{15.2, 0},
           {-9.2, 0}}, color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-40, -40},
-            {40, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {40, 40}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end PDtoTD;

--- a/PNlib/Examples/DisTest/SinglePD.mo
+++ b/PNlib/Examples/DisTest/SinglePD.mo
@@ -5,5 +5,5 @@ model SinglePD
   PNlib.PD P1 annotation(Placement(visible = true, transformation(origin={0, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   inner PNlib.Settings settings annotation(Placement(visible = true, transformation(origin={30, 30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   annotation(Diagram(coordinateSystem(extent={{-40, -40},
-            {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime=0.0, StopTime=1.0));
+            {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime=0.0, StopTime=1.0, Tolerance = 1e-6));
 end SinglePD;

--- a/PNlib/Examples/DisTest/SingleTD.mo
+++ b/PNlib/Examples/DisTest/SingleTD.mo
@@ -5,5 +5,5 @@ model SingleTD
   PNlib.TD T1 annotation(Placement(visible = true, transformation(origin = {0, 0}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   inner PNlib.Settings settings annotation(Placement(visible = true, transformation(origin={30, 30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
   annotation(Diagram(coordinateSystem(extent={{-40, -40},
-            {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime=0.0, StopTime=1.0));
+            {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime=0.0, StopTime=1.0, Tolerance = 1e-6));
 end SingleTD;

--- a/PNlib/Examples/DisTest/SixConflictProb.mo
+++ b/PNlib/Examples/DisTest/SixConflictProb.mo
@@ -33,5 +33,5 @@ equation
           -40}, {-20, -40}, {-20, 0.833333}, {-29.2, 0.833333}},
                                                       color = {0, 0, 0}, smooth = Smooth.None));
   annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent={{-60, -60},
-            {40, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+            {40, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end SixConflictProb;

--- a/PNlib/Examples/DisTest/TDtoPD.mo
+++ b/PNlib/Examples/DisTest/TDtoPD.mo
@@ -9,5 +9,5 @@ equation
   connect(P1.inTransition[1], T1.outPlaces[1]) annotation(Line(points={{9.2, 0}, {
           9.2, 0}, {-15.2, 0}}));
   annotation(Diagram(coordinateSystem(extent={{-40, -40},
-            {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime=0.0, StopTime=10.0));
+            {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end TDtoPD;

--- a/PNlib/Examples/ExtTest/DoubleArcwithPCtoTC.mo
+++ b/PNlib/Examples/ExtTest/DoubleArcwithPCtoTC.mo
@@ -16,5 +16,5 @@ equation
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points={{20.8, -30}, {29.2, -30}}, color={0, 0, 0}));
   connect(IA1.outTransition, T1.inPlaces[1]) annotation(Line(points={{-6.88889, 29}, {-2.44445, 29}, {-2.44445, 30}, {11.2, 30}}, color={0, 0, 0}));
   connect(IA1.inPlace, P1.outTransition[2]) annotation(Line(points={{-23.1111, 29}, {-23.1111, 30}, {-30, 30}, {-30, 0}, {-33.2, 0}, {-33.2, 0.5}}, color={0, 0, 0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}})), experiment(StartTime=0.0, StopTime=10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}})), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end DoubleArcwithPCtoTC;

--- a/PNlib/Examples/ExtTest/DoubleArcwithPTtoTD.mo
+++ b/PNlib/Examples/ExtTest/DoubleArcwithPTtoTD.mo
@@ -16,5 +16,5 @@ equation
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points={{20.8, -28}, {29.2, -28}}, color={0, 0, 0}));
   connect(IA1.inPlace, P1.outTransition[2]) annotation(Line(points={{-24.9524, 30}, {-28, 30}, {-28, 2.5}, {-33.2, 2.5}}, color={0, 0, 0}));
   connect(IA1.outTransition, T1.inPlaces[1]) annotation(Line(points={{-11.0476, 30}, {-11.0476, 30}, {11.2, 30}}, color={0, 0, 0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}})), experiment(StartTime=0.0, StopTime=10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}})), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end DoubleArcwithPTtoTD;

--- a/PNlib/Examples/ExtTest/IATest.mo
+++ b/PNlib/Examples/ExtTest/IATest.mo
@@ -19,5 +19,5 @@ equation
   connect(IA2.outTransition, T3.inPlaces[1]) annotation(Line(points={{56.9524, -1}, {56.9524, 0}, {66, 0}, {76, 0}, {76, -0.5}, {75.2, -0.5}}, color={0, 0, 0}));
   connect(P1.outTransition[2], T3.inPlaces[2]) annotation(Line(points={{-49.2, 0.5}, {-48, 0.5}, {-48, -20}, {66, -20}, {66, -4}, {66, 0.5}, {75.2, 0.5}}, color={0, 0, 0}));
   connect(T3.outPlaces[1], P3.inTransition[1]) annotation(Line(points={{84.8, 0}, {89.2, 0}}, color={0, 0, 0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100, -40}, {120, 40}})), experiment(StartTime=0.0, StopTime=6.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100, -40}, {120, 40}})), experiment(StartTime=0.0, StopTime=6.0, Tolerance = 1e-6));
 end IATest;

--- a/PNlib/Examples/ExtTest/IAwithPCtoTC.mo
+++ b/PNlib/Examples/ExtTest/IAwithPCtoTC.mo
@@ -14,5 +14,5 @@ equation
   connect(P1.outTransition[2], TA1.inPlace) annotation(Line(points={{-33.2, 0.5}, {-28, 0.5}, {-28, -31}, {-21.1111, -31}}, color={0, 0, 0}));
   connect(TA1.outTransition, T2.inPlaces[1]) annotation(Line(points={{-4.88889, -31}, {1.5556, -31}, {1.5556, -30}, {11.2, -30}}, color={0, 0, 0}));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points={{20.8, -30}, {29.2, -30}}, color={0, 0, 0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end IAwithPCtoTC;

--- a/PNlib/Examples/ExtTest/IAwithPDtoTD.mo
+++ b/PNlib/Examples/ExtTest/IAwithPDtoTD.mo
@@ -14,5 +14,5 @@ equation
   connect(P1.outTransition[2], TA1.inPlace) annotation(Line(points={{-33.2, -1.5}, {-28, -1.5}, {-28, -33}, {-21.1111, -33}}, color={0, 0, 0}));
   connect(TA1.outTransition, T2.inPlaces[1]) annotation(Line(points={{-4.88889, -33}, {1.5556, -33}, {1.5556, -32}, {11.2, -32}}, color={0, 0, 0}));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points={{20.8, -32}, {29.2, -32}}, color={0, 0, 0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end IAwithPDtoTD;

--- a/PNlib/Examples/ExtTest/TATest.mo
+++ b/PNlib/Examples/ExtTest/TATest.mo
@@ -17,5 +17,5 @@ equation
   connect(P2.outTransition[1], TA2. inPlace) annotation(Line(points={{30.8, 0}, {38, 0}, {38, -1}, {43.0476, -1}}, color={0, 0, 0}));
   connect(TA2.outTransition, T3. inPlaces[1]) annotation(Line(points={{56.9524, -1}, {56.9524, 0}, {66, 0}, {76, 0}, {76, -0.5}, {75.2, -0.5}}, color={0, 0, 0}));
   connect(P1.outTransition[2], T3. inPlaces[2]) annotation(Line(points={{-49.2, 0.5}, {-48, 0.5}, {-48, -20}, {66, -20}, {66, -4}, {66, 0.5}, {75.2, 0.5}}, color={0, 0, 0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100, -40}, {100, 40}})), experiment(StartTime=0.0, StopTime=6.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-100, -40}, {100, 40}})), experiment(StartTime=0.0, StopTime=6.0, Tolerance = 1e-6));
 end TATest;

--- a/PNlib/Examples/ExtTest/TAwithPCtoTC.mo
+++ b/PNlib/Examples/ExtTest/TAwithPCtoTC.mo
@@ -14,5 +14,5 @@ equation
   connect(P1.outTransition[2], TA1.inPlace) annotation(Line(points={{-33.2, 0.5}, {-28, 0.5}, {-28, -31}, {-21.1111, -31}}, color={0, 0, 0}));
   connect(TA1.outTransition, T2.inPlaces[1]) annotation(Line(points={{-4.88889, -31}, {1.5556, -31}, {1.5556, -30}, {11.2, -30}}, color={0, 0, 0}));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points={{20.8, -30}, {29.2, -30}}, color={0, 0, 0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end TAwithPCtoTC;

--- a/PNlib/Examples/ExtTest/TAwithPDtoTD.mo
+++ b/PNlib/Examples/ExtTest/TAwithPDtoTD.mo
@@ -14,5 +14,5 @@ equation
   connect(P1.outTransition[2], TA1.inPlace) annotation(Line(points={{-31.2, 0.5}, {-26, 0.5}, {-26, -33}, {-19.1111, -33}}, color={0, 0, 0}));
   connect(TA1.outTransition, T2.inPlaces[1]) annotation(Line(points={{-2.88889, -33}, {3.55556, -33}, {3.55556, -30}, {11.2, -30}}, color={0, 0, 0}));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points={{20.8, -30}, {20.8, -30}, {29.2, -30}}, color={0, 0, 0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}}), graphics), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end TAwithPDtoTD;

--- a/PNlib/Examples/ExtTest/TAwithWeaklyActivation.mo
+++ b/PNlib/Examples/ExtTest/TAwithWeaklyActivation.mo
@@ -14,5 +14,5 @@ equation
   connect(T2.outPlaces[1], P2.inTransition[1]) annotation(Line(points={{34.8, 20}, {34.8, 20}, {49.2, 20}}, color={0, 0, 0}));
   connect(T3.inPlaces[1], P1.outTransition[2]) annotation(Line(points={{25.2, 60}, {-10, 60}, {-10, 40.5}, {-19.2, 40.5}}, color={0, 0, 0}));
   connect(TA1.outTransition, T2.inPlaces[1]) annotation(Line(points={{17.1111, 20}, {17.1111, 20}, {25.2, 20}}, color={0, 0, 0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-80, 0}, {80, 80}})), experiment(StartTime=0.0, StopTime=5.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-80, 0}, {80, 80}})), experiment(StartTime=0.0, StopTime=5.0, Tolerance = 1e-6));
 end TAwithWeaklyActivation;

--- a/PNlib/Examples/ExtTest/TSTest.mo
+++ b/PNlib/Examples/ExtTest/TSTest.mo
@@ -8,5 +8,5 @@ model TSTest
 equation
   connect(P1.outTransition[1], T1.inPlaces[1]) annotation(Line(points={{-19.2, 0}, {-4.8, 0}}, color={0, 0, 0}));
   connect(T1.outPlaces[1], P2.inTransition[1]) annotation(Line(points={{4.8, 0}, {19.2, 0}}, color={0, 0, 0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-40, -40}, {40, 40}})), experiment(StartTime=0.0, StopTime=10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-40, -40}, {40, 40}})), experiment(StartTime=0.0, StopTime=10.0, Tolerance = 1e-6));
 end TSTest;

--- a/PNlib/Examples/HybTest/ConflictPrio.mo
+++ b/PNlib/Examples/HybTest/ConflictPrio.mo
@@ -15,5 +15,5 @@ equation
   connect(T1.outPlaces[1], P2.inTransition[1]) annotation(Line(points = {{14.8, 20}, {29.2, 20}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.inPlaces[1], P1.outTransition[2]) annotation(Line(points = {{5.2, -20}, {-0.4, -20}, {-0.4, 0.5}, {-9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points = {{14.8, -20}, {29.2, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -40}, {60, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -40}, {60, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end ConflictPrio;

--- a/PNlib/Examples/HybTest/ConflictProb.mo
+++ b/PNlib/Examples/HybTest/ConflictProb.mo
@@ -21,5 +21,5 @@ equation
   connect(T1.outPlaces[1], P2.inTransition[1]) annotation(Line(points = {{14.8, 20}, {29.2, 20}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.inPlaces[1], P1.outTransition[2]) annotation(Line(points = {{5.2, -20}, {-0.4, -20}, {-0.4, 0.5}, {-9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points = {{14.8, -20}, {29.2, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(experiment(StartTime = 0.0, StopTime = 10.0), Diagram(coordinateSystem(extent = {{-60, -40}, {60, 40}})));
+  annotation(experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6), Diagram(coordinateSystem(extent = {{-60, -40}, {60, 40}})));
 end ConflictProb;

--- a/PNlib/Examples/HybTest/ConflictType3.mo
+++ b/PNlib/Examples/HybTest/ConflictType3.mo
@@ -15,5 +15,5 @@ equation
   connect(T1.outPlaces[1], P2.inTransition[1]) annotation(Line(points = {{14.8, 20}, {29.2, 20}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.inPlaces[1], P1.outTransition[2]) annotation(Line(points = {{5.2, -20}, {-0.4, -20}, {-0.4, 0.5}, {-9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points = {{14.8, -20}, {29.2, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -40}, {60, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -40}, {60, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end ConflictType3;

--- a/PNlib/Examples/HybTest/ConflictType4.mo
+++ b/PNlib/Examples/HybTest/ConflictType4.mo
@@ -19,5 +19,5 @@ equation
   connect(T1.outPlaces[1], P4.inTransition[1]) annotation(Line(points={{4.8, -40.5}, {29.2, -40.5}, {29.2, -40}}, color={0, 0, 0}));
   connect(P5.outTransition[2], T1.inPlaces[2]) annotation(Line(points={{-10.8, -9.5}, {-20, -9.5}, {-20, -39.5}, {-4.8, -39.5}}, color={0, 0, 0}));
   connect(P5.inTransition[2], T1.outPlaces[2]) annotation(Line(points={{10.8, -9.5}, {20, -9.5}, {20, -39.5}, {4.8, -39.5}}, color={0, 0, 0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}})), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60, -60}, {60, 60}})), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end ConflictType4;

--- a/PNlib/Examples/HybTest/EightConflictProb.mo
+++ b/PNlib/Examples/HybTest/EightConflictProb.mo
@@ -22,5 +22,5 @@ equation
   connect(T6.inPlaces[1], P1.outTransition[6]) annotation(Line(points = {{-14.8, -40}, {-20, -40}, {-20, 0.375}, {-29.2, 0.375}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T7.inPlaces[1], P1.outTransition[7]) annotation(Line(points = {{25.2, -30}, {20, -30}, {20, 0.625}, {-29.2, 0.625}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T8.inPlaces[1], P1.outTransition[8]) annotation(Line(points = {{5.2, -20}, {-0.4, -20}, {-0.4, 0.875}, {-29.2, 0.875}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -60}, {60, 60}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -60}, {60, 60}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end EightConflictProb;

--- a/PNlib/Examples/HybTest/HybLoopAndArcweight.mo
+++ b/PNlib/Examples/HybTest/HybLoopAndArcweight.mo
@@ -8,5 +8,5 @@ model HybLoopAndArcweight
 equation
   connect(P1.outTransition[1], T1.inPlaces[1]) annotation(Line(points = {{10.8, -20}, {20, -20}, {20, 20}, {2.8, 20}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T1.outPlaces[1], P1.inTransition[1]) annotation(Line(points = {{-6.8, 20}, {-20, 20}, {-20, -20}, {-10.8, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-40, -40}, {40, 60}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-40, -40}, {40, 60}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end HybLoopAndArcweight;

--- a/PNlib/Examples/HybTest/InputConflictPrio.mo
+++ b/PNlib/Examples/HybTest/InputConflictPrio.mo
@@ -15,5 +15,5 @@ equation
   connect(T2.outPlaces[1], P1.inTransition[1]) annotation(Line(points = {{-5.2, 20}, {0, 20}, {0, -0.5}, {9.2, -0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T3.outPlaces[1], P1.inTransition[2]) annotation(Line(points = {{-5.2, -20}, {0, -20}, {0, 0.5}, {9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T1.inPlaces[1], P1.outTransition[1]) annotation(Line(points = {{45.2, 0}, {30.8, 0}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -40}, {60, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -40}, {60, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end InputConflictPrio;

--- a/PNlib/Examples/HybTest/InputConflictProb.mo
+++ b/PNlib/Examples/HybTest/InputConflictProb.mo
@@ -20,5 +20,5 @@ equation
   connect(T2.outPlaces[1], P1.inTransition[1]) annotation(Line(points = {{-5.2, 20}, {0, 20}, {0, -0.5}, {9.2, -0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T3.outPlaces[1], P1.inTransition[2]) annotation(Line(points = {{-5.2, -20}, {0, -20}, {0, 0.5}, {9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T1.inPlaces[1], P1.outTransition[1]) annotation(Line(points = {{45.2, 0}, {30.8, 0}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(experiment(StartTime = 0.0, StopTime = 10.0), Diagram(coordinateSystem(extent = {{-60, -40}, {60, 40}})));
+  annotation(experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6), Diagram(coordinateSystem(extent = {{-60, -40}, {60, 40}})));
 end InputConflictProb;

--- a/PNlib/Examples/HybTest/InputConflictType3.mo
+++ b/PNlib/Examples/HybTest/InputConflictType3.mo
@@ -14,5 +14,5 @@ equation
   connect(T2.outPlaces[1], P1.inTransition[1]) annotation(Line(points={{-5.2, 20}, {0, 20}, {0, -0.5}, {9.2, -0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T3.outPlaces[1], P1.inTransition[2]) annotation(Line(points={{-5.2, -20}, {0, -20}, {0, 0.5}, {9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T1.inPlaces[1], P1.outTransition[1]) annotation(Line(points={{45.2, 0}, {30.8, 0}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -40}, {60, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -40}, {60, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end InputConflictType3;

--- a/PNlib/Examples/HybTest/OutputConflictPrio.mo
+++ b/PNlib/Examples/HybTest/OutputConflictPrio.mo
@@ -15,5 +15,5 @@ equation
   connect(T1.outPlaces[1], P2.inTransition[1]) annotation(Line(points = {{14.8, 20}, {29.2, 20}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.inPlaces[1], P1.outTransition[2]) annotation(Line(points = {{5.2, -20}, {-0.4, -20}, {-0.4, 0.5}, {-9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points = {{14.8, -20}, {29.2, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(experiment(StartTime = 0.0, StopTime = 10.0), Diagram(coordinateSystem(extent = {{-60, -40}, {60, 40}})));
+  annotation(experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6), Diagram(coordinateSystem(extent = {{-60, -40}, {60, 40}})));
 end OutputConflictPrio;

--- a/PNlib/Examples/HybTest/OutputConflictProb.mo
+++ b/PNlib/Examples/HybTest/OutputConflictProb.mo
@@ -20,5 +20,5 @@ equation
   connect(T1.outPlaces[1], P2.inTransition[1]) annotation(Line(points = {{14.8, 20}, {29.2, 20}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.inPlaces[1], P1.outTransition[2]) annotation(Line(points = {{5.2, -20}, {-0.4, -20}, {-0.4, 0.5}, {-9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points = {{14.8, -20}, {29.2, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(experiment(StartTime = 0.0, StopTime = 10.0), Diagram(coordinateSystem(extent = {{-60, -40}, {60, 40}})));
+  annotation(experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6), Diagram(coordinateSystem(extent = {{-60, -40}, {60, 40}})));
 end OutputConflictProb;

--- a/PNlib/Examples/HybTest/OutputConflictType3.mo
+++ b/PNlib/Examples/HybTest/OutputConflictType3.mo
@@ -15,5 +15,5 @@ equation
   connect(T1.outPlaces[1], P2.inTransition[1]) annotation(Line(points = {{14.8, 20}, {29.2, 20}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.inPlaces[1], P1.outTransition[2]) annotation(Line(points = {{5.2, -20}, {-0.4, -20}, {-0.4, 0.5}, {-9.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T2.outPlaces[1], P3.inTransition[1]) annotation(Line(points = {{14.8, -20}, {29.2, -20}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -40}, {60, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -40}, {60, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end OutputConflictType3;

--- a/PNlib/Examples/HybTest/PCtoTD.mo
+++ b/PNlib/Examples/HybTest/PCtoTD.mo
@@ -7,5 +7,5 @@ model PCtoTD
   PNlib.TD T1(nIn=1, delay=1, arcWeightIn={1}) annotation(Placement(transformation(extent = {{10, -10}, {30, 10}})));
 equation
   connect(T1.inPlaces[1], P1.outTransition[1]) annotation(Line(points = {{15.2, 0}, {-9.2, 0}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-40, -40}, {40, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-40, -40}, {40, 40}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end PCtoTD;

--- a/PNlib/Examples/HybTest/SixConflictProb.mo
+++ b/PNlib/Examples/HybTest/SixConflictProb.mo
@@ -22,5 +22,5 @@ equation
   connect(T5.inPlaces[1], P1.outTransition[5]) annotation(Line(points = {{5.2, -30}, {0, -30}, {0, 0.5}, {-29.2, 0.5}}, color = {0, 0, 0}, smooth = Smooth.None));
   connect(T6.inPlaces[1], P1.outTransition[6]) annotation(Line(points={{-14.8,
           -40}, {-20, -40}, {-20, 0.833333}, {-29.2, 0.833333}}, color = {0, 0, 0}, smooth = Smooth.None));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -60}, {40, 60}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio = false, extent = {{-60, -60}, {40, 60}}), graphics), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end SixConflictProb;

--- a/PNlib/Examples/HybTest/TCwithPD.mo
+++ b/PNlib/Examples/HybTest/TCwithPD.mo
@@ -12,5 +12,5 @@ equation
   connect(T1.outPlaces[1], P2.inTransition[1]) annotation(Line(points={{4.8,19.5},{12,19.5},{12,20},{29.2,20}}, color={0,0,0}));
   connect(P3.outTransition[1], T1.inPlaces[2]) annotation(Line(points={{-10.8,-10},{-20,-10},{-20,20.5},{-4.8,20.5}}, color={0,0,0}));
   connect(T1.outPlaces[2], P3.inTransition[1]) annotation(Line(points={{4.8,20.5},{20,20.5},{20,-10},{10.8,-10}}, color={0,0,0}));
-  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60,-60},{60,60}})), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(preserveAspectRatio=false, extent={{-60,-60},{60,60}})), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end TCwithPD;

--- a/PNlib/Examples/HybTest/TDtoPC.mo
+++ b/PNlib/Examples/HybTest/TDtoPC.mo
@@ -7,5 +7,5 @@ model TDtoPC
   inner PNlib.Settings settings annotation(Placement(visible = true, transformation(origin = {30, 30}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
 equation
   connect(P1.inTransition[1], T1.outPlaces[1]) annotation(Line(points = {{9.2, 0}, {9.2, 0}, {-15.2, 0}}));
-  annotation(Diagram(coordinateSystem(extent = {{-40, -40}, {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime = 0.0, StopTime = 10.0));
+  annotation(Diagram(coordinateSystem(extent = {{-40, -40}, {40, 40}}, preserveAspectRatio = true, initialScale = 0.1, grid = {2, 2})), experiment(StartTime = 0.0, StopTime = 10.0, Tolerance = 1e-6));
 end TDtoPC;

--- a/PNlib/Examples/Models/FlushToilet.mo
+++ b/PNlib/Examples/Models/FlushToilet.mo
@@ -258,7 +258,7 @@ equation
         coordinateSystem(preserveAspectRatio=true, extent={{-125,-125},{125,125}}),
         graphics),
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-125,-125},{125,125}})),
-    experiment(StopTime=100),
+    experiment(StopTime=100, Tolerance = 1e-6),
     __Dymola_experimentSetupOutput,
                 Documentation(info="<html>
   <p>

--- a/PNlib/Examples/Models/PNproBP/Model.mo
+++ b/PNlib/Examples/Models/PNproBP/Model.mo
@@ -578,5 +578,5 @@ equation
             {420,200}}),
                     graphics),
     Icon(coordinateSystem(preserveAspectRatio=true, extent={{-420,-145},{420,200}})),
-    experiment(StopTime=320));
+    experiment(StopTime=320, Tolerance = 1e-6));
 end Model;

--- a/PNlib/Examples/Models/Printing/Model.mo
+++ b/PNlib/Examples/Models/Printing/Model.mo
@@ -194,6 +194,6 @@ equation
           fillPattern=FillPattern.Solid,
           textString=DynamicSelect("0",realString(duration__,1,0)))}), Icon(coordinateSystem(preserveAspectRatio=true,
           extent={{-125,-125},{125,125}})),
-    experiment(StopTime=32000),
+    experiment(StopTime=32000, Tolerance = 1e-6),
     __Dymola_experimentSetupOutput);
 end Model;

--- a/PNlib/Examples/Models/Senseo/Senseo_Model.mo
+++ b/PNlib/Examples/Models/Senseo/Senseo_Model.mo
@@ -81,5 +81,5 @@ equation
             -100},{120,80}}),
                       graphics), Icon(coordinateSystem(
           preserveAspectRatio=true, extent={{-100,-100},{120,80}})),
-    experiment(StopTime=18000));
+    experiment(StopTime=18000, Tolerance = 1e-6));
 end Senseo_Model;

--- a/Testing/Makefile
+++ b/Testing/Makefile
@@ -3,14 +3,16 @@
 test: openmodelica dymola
 
 openmodelica:
-	@make -C OpenModelica > openmodelica.log 2>&1
+	@make -C OpenModelica | tee openmodelica.log
 	@make -C OpenModelica clean
-	@tail -2 openmodelica.log | head -1
+	@echo ""
+	@grep == openmodelica.log
 
 dymola:
-	@make -C Dymola > dymola.log 2>&1
+	@make -C Dymola | tee dymola.log
 	@make -C Dymola clean
-	@tail -2 dymola.log | head -1
+	@echo ""
+	@grep == dymola.log
 
 clean:
 	@make -C OpenModelica clean


### PR DESCRIPTION
Example `PNlib.Examples.HybTest.ConflictType3` does not work with too small value for `PNlib.Constants.almost_eps`.