### PR TITLE
Workload

### DIFF
--- a/PNlib/Examples/Models/FlushToilet.mo
+++ b/PNlib/Examples/Models/FlushToilet.mo
@@ -1,6 +1,14 @@
 within PNlib.Examples.Models;
 model FlushToilet "Model of a flush toilet"
   extends Modelica.Icons.Example;
+  import PNlib.Components.PC;
+  import PNlib.Components.PD;
+  import PNlib.Components.TD;
+  import PNlib.Components.TC;
+  import PNlib.Components.TA;
+  import PNlib.Components.IA;
+  import PNlib.Components.Settings;
+  import PNlib.Components.TDS;
   PD Lever(nIn=1,
     maxTokens=1,
     nOut=1) "Lever of the toilet" annotation(Placement(transformation(

--- a/PNlib/Examples/Models/PNproBP/Model.mo
+++ b/PNlib/Examples/Models/PNproBP/Model.mo
@@ -1,6 +1,20 @@
 within PNlib.Examples.Models.PNproBP;
 model Model "Top Model"
   extends Modelica.Icons.Example;
+  import PNlib.Components.PD;
+  import PNlib.Components.PC;
+  import PNlib.Components.T;
+  import PNlib.Components.TD;
+  import PNlib.Components.TDS;
+  import PNlib.Components.TE;
+  import PNlib.Components.TES;
+  import PNlib.Components.TFD;
+  import PNlib.Components.TFDS;
+  import PNlib.Components.TT;
+  import PNlib.Components.TC;
+  import PNlib.Components.TA;
+  import PNlib.Components.IA;
+  import PNlib.Components.Settings;
   parameter Integer Nr_Consultant=2 "Number of consultants";
   parameter Integer Nr_Advisor1=2 "Number of advisor type 1";
   parameter Integer Nr_Advisor2=1 "Number of advisor type 2";

--- a/PNlib/Examples/Models/PNproBP/Parallel.mo
+++ b/PNlib/Examples/Models/PNproBP/Parallel.mo
@@ -1,5 +1,19 @@
 within PNlib.Examples.Models.PNproBP;
 model Parallel
+  import PNlib.Components.PD;
+  import PNlib.Components.PC;
+  import PNlib.Components.T;
+  import PNlib.Components.TD;
+  import PNlib.Components.TDS;
+  import PNlib.Components.TE;
+  import PNlib.Components.TES;
+  import PNlib.Components.TFD;
+  import PNlib.Components.TFDS;
+  import PNlib.Components.TT;
+  import PNlib.Components.TC;
+  import PNlib.Components.TA;
+  import PNlib.Components.IA;
+  import PNlib.Components.Settings;
   parameter Real delay=1;
   parameter Real noParallel=2;
   Real arcWeightIn[nIn]=fill(1,nIn) "arc weights of input place" annotation(Dialog(enable = true, group = "Arc Weights"));

--- a/PNlib/Examples/Models/PNproBP/Puffer.mo
+++ b/PNlib/Examples/Models/PNproBP/Puffer.mo
@@ -1,5 +1,19 @@
 within PNlib.Examples.Models.PNproBP;
 model Puffer
+  import PNlib.Components.PD;
+  import PNlib.Components.PC;
+  import PNlib.Components.T;
+  import PNlib.Components.TD;
+  import PNlib.Components.TDS;
+  import PNlib.Components.TE;
+  import PNlib.Components.TES;
+  import PNlib.Components.TFD;
+  import PNlib.Components.TFDS;
+  import PNlib.Components.TT;
+  import PNlib.Components.TC;
+  import PNlib.Components.TA;
+  import PNlib.Components.IA;
+  import PNlib.Components.Settings;
  parameter Real delay=1;
  parameter Integer nIn=0 "number of input places" annotation(Dialog(connectorSizing=true));
   parameter Integer nOut=0 "number of output places" annotation(Dialog(connectorSizing=true));

--- a/PNlib/Examples/Models/PNproBP/Waiting.mo
+++ b/PNlib/Examples/Models/PNproBP/Waiting.mo
@@ -1,5 +1,19 @@
 within PNlib.Examples.Models.PNproBP;
 model Waiting
+  import PNlib.Components.PD;
+  import PNlib.Components.PC;
+  import PNlib.Components.T;
+  import PNlib.Components.TD;
+  import PNlib.Components.TDS;
+  import PNlib.Components.TE;
+  import PNlib.Components.TES;
+  import PNlib.Components.TFD;
+  import PNlib.Components.TFDS;
+  import PNlib.Components.TT;
+  import PNlib.Components.TC;
+  import PNlib.Components.TA;
+  import PNlib.Components.IA;
+  import PNlib.Components.Settings;
   parameter Real delay=1;
    Integer arcWeight=1;
   Boolean fire "firability of continuous transition";

--- a/PNlib/Examples/Models/PNproBP/Workload.mo
+++ b/PNlib/Examples/Models/PNproBP/Workload.mo
@@ -1,21 +1,26 @@
 within PNlib.Examples.Models.PNproBP;
 model Workload
-  Real cap;
+  Real cap(start=0);
+  parameter Integer max_tokens = 1;
   Modelica.Blocks.Interfaces.IntegerInput u annotation(Placement(
         transformation(
         extent={{-20,-20},{20,20}},
         rotation=0,
         origin={-120,0})));
   Integer[3] color;
-protected
+//protected
   Real help1;
+  Real help2 = time - help1;
+  Real help3 = (max_tokens - u) * help2;
+  Integer i(start = 0);
 algorithm
-  when  u==0 then
+  when pre(u)==u and u <> max_tokens  then
     help1:=time;
     color:={255,0,0};
-  elsewhen u>0 then
-    cap:=cap + time - help1;
+  elsewhen pre(u) <> max_tokens and pre(u) <> u then
+    cap:= cap + help3;
     color:={128,255,0};
+    i:= i+1;
   end when;
 
   annotation(Icon(coordinateSystem(

--- a/PNlib/Examples/Models/PNproBP/XOR.mo
+++ b/PNlib/Examples/Models/PNproBP/XOR.mo
@@ -1,5 +1,19 @@
 within PNlib.Examples.Models.PNproBP;
 model XOR
+  import PNlib.Components.PD;
+  import PNlib.Components.PC;
+  import PNlib.Components.T;
+  import PNlib.Components.TD;
+  import PNlib.Components.TDS;
+  import PNlib.Components.TE;
+  import PNlib.Components.TES;
+  import PNlib.Components.TFD;
+  import PNlib.Components.TFDS;
+  import PNlib.Components.TT;
+  import PNlib.Components.TC;
+  import PNlib.Components.TA;
+  import PNlib.Components.IA;
+  import PNlib.Components.Settings;
  parameter Real upperProb=0.5;
  parameter Real lowerProb=0.5;
  Real arcWeightOut1=1 "arc weights of output place"

--- a/PNlib/Examples/Models/Senseo/Insert_Pad.mo
+++ b/PNlib/Examples/Models/Senseo/Insert_Pad.mo
@@ -1,6 +1,20 @@
 within PNlib.Examples.Models.Senseo;
 model Insert_Pad
   "Insert pad: coffee pads are inserted to the Senseo machine (step 5)."
+  import PNlib.Components.PD;
+  import PNlib.Components.PC;
+  import PNlib.Components.T;
+  import PNlib.Components.TD;
+  import PNlib.Components.TDS;
+  import PNlib.Components.TE;
+  import PNlib.Components.TES;
+  import PNlib.Components.TFD;
+  import PNlib.Components.TFDS;
+  import PNlib.Components.TT;
+  import PNlib.Components.TC;
+  import PNlib.Components.TA;
+  import PNlib.Components.IA;
+  import PNlib.Components.Settings;
 
   TDS       inserting2(
     nIn=1,

--- a/PNlib/Examples/Models/Senseo/Refill_Water.mo
+++ b/PNlib/Examples/Models/Senseo/Refill_Water.mo
@@ -1,6 +1,20 @@
 within PNlib.Examples.Models.Senseo;
 model Refill_Water
   "Refilling water: the water tank of the Senseo machine is refilled (step 3)."
+  import PNlib.Components.PD;
+  import PNlib.Components.PC;
+  import PNlib.Components.T;
+  import PNlib.Components.TD;
+  import PNlib.Components.TDS;
+  import PNlib.Components.TE;
+  import PNlib.Components.TES;
+  import PNlib.Components.TFD;
+  import PNlib.Components.TFDS;
+  import PNlib.Components.TT;
+  import PNlib.Components.TC;
+  import PNlib.Components.TA;
+  import PNlib.Components.IA;
+  import PNlib.Components.Settings;
 
   TD       refilling2(
     nIn=1,

--- a/PNlib/Examples/Models/Senseo/Senseo_Maschine.mo
+++ b/PNlib/Examples/Models/Senseo/Senseo_Maschine.mo
@@ -1,6 +1,20 @@
 within PNlib.Examples.Models.Senseo;
 model Senseo_Maschine
   "Senseo machine: the functionality of the Senseo machine (step 4, 6, 7, 8, 9, 10)."
+  import PNlib.Components.PD;
+  import PNlib.Components.PC;
+  import PNlib.Components.T;
+  import PNlib.Components.TD;
+  import PNlib.Components.TDS;
+  import PNlib.Components.TE;
+  import PNlib.Components.TES;
+  import PNlib.Components.TFD;
+  import PNlib.Components.TFDS;
+  import PNlib.Components.TT;
+  import PNlib.Components.TC;
+  import PNlib.Components.TA;
+  import PNlib.Components.IA;
+  import PNlib.Components.Settings;
   parameter Real Psenseo=1.450 "power of senseo machine [kW]";
   parameter Real c=4.182 "specific heat capacity [kJ/(kg*K)]";
   parameter Real k=0.01177 "proportionality factor for cooling water";

--- a/PNlib/Examples/Models/Senseo/Start.mo
+++ b/PNlib/Examples/Models/Senseo/Start.mo
@@ -1,6 +1,20 @@
 within PNlib.Examples.Models.Senseo;
 model Start
   "User action: starting and stopping the machine (step 1, 2, 11), initiating the insertion of coffee pads (step 5) and the refill of water (step 3)."
+  import PNlib.Components.PD;
+  import PNlib.Components.PC;
+  import PNlib.Components.T;
+  import PNlib.Components.TD;
+  import PNlib.Components.TDS;
+  import PNlib.Components.TE;
+  import PNlib.Components.TES;
+  import PNlib.Components.TFD;
+  import PNlib.Components.TFDS;
+  import PNlib.Components.TT;
+  import PNlib.Components.TC;
+  import PNlib.Components.TA;
+  import PNlib.Components.IA;
+  import PNlib.Components.Settings;
   parameter Real EV_time=600;
   TDS starting(
     h=1/EV_time,

--- a/PNlib/Examples/Models/Senseo/Water_Tank.mo
+++ b/PNlib/Examples/Models/Senseo/Water_Tank.mo
@@ -1,6 +1,20 @@
 within PNlib.Examples.Models.Senseo;
 model Water_Tank "Water tank: the water tank of the Senseo machine."
   Real level "Tank level in % of max height";
+  import PNlib.Components.PD;
+  import PNlib.Components.PC;
+  import PNlib.Components.T;
+  import PNlib.Components.TD;
+  import PNlib.Components.TDS;
+  import PNlib.Components.TE;
+  import PNlib.Components.TES;
+  import PNlib.Components.TFD;
+  import PNlib.Components.TFDS;
+  import PNlib.Components.TT;
+  import PNlib.Components.TC;
+  import PNlib.Components.TA;
+  import PNlib.Components.IA;
+  import PNlib.Components.Settings;
   parameter Real color[3]={0,0,255};
   PC       water_tank(
     nOut=3,

--- a/PNlib/Examples/TestWorkload.mo
+++ b/PNlib/Examples/TestWorkload.mo
@@ -1,0 +1,29 @@
+within PNlib.Examples;
+
+model TestWorkload
+  extends Modelica.Icons.Example;
+  parameter Integer no_cons = 3;
+  PNlib.Components.PD P1(maxTokens = no_cons, nIn = 1, nOut = 1, startTokens = no_cons)  annotation(
+    Placement(visible = true, transformation(origin = {0, 6}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PNlib.Examples.Models.PNproBP.Workload workload1(max_tokens = no_cons)  annotation(
+    Placement(visible = true, transformation(origin = {0, 32}, extent = {{-5, -5}, {5, 5}}, rotation = 90)));
+  PNlib.Components.TD T1(nIn = 1, nOut = 1)  annotation(
+    Placement(visible = true, transformation(origin = {32, 6}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PNlib.Components.PD P11(nIn = 1)  annotation(
+    Placement(visible = true, transformation(origin = {66, 8}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  inner PNlib.Components.Settings settings annotation(
+    Placement(visible = true, transformation(origin = {-56, 60}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+  PNlib.Components.TE T11(event = {3, 7, 7.5}, nOut = 1)  annotation(
+    Placement(visible = true, transformation(origin = {-44, 6}, extent = {{-10, -10}, {10, 10}}, rotation = 0)));
+equation
+  connect(T11.outPlaces[1], P1.inTransition[1]) annotation(
+    Line(points = {{-40, 6}, {-10, 6}, {-10, 6}, {-10, 6}}, thickness = 0.5));
+  connect(T1.outPlaces[1], P11.inTransition[1]) annotation(
+    Line(points = {{36, 6}, {56, 6}, {56, 8}, {56, 8}, {56, 8}}, thickness = 0.5));
+  connect(P1.outTransition[1], T1.inPlaces[1]) annotation(
+    Line(points = {{10, 6}, {28, 6}, {28, 6}, {28, 6}, {28, 6}}, thickness = 0.5));
+  connect(P1.pd_t, workload1.u) annotation(
+    Line(points = {{0, 16}, {0, 16}, {0, 26}, {0, 26}}, color = {255, 127, 0}));
+  annotation(
+    uses(PNlib(version = "2.0")));
+end TestWorkload;

--- a/PNlib/Examples/package.order
+++ b/PNlib/Examples/package.order
@@ -3,3 +3,4 @@ DisTest
 ExtTest
 HybTest
 Models
+TestWorkload


### PR DESCRIPTION
Workload.mo: As I understand, the workload should monitor the timeunits of manwork. If the time unit is hour and e.g 2 Consultants are available, currenty workload is only added when both consultans are busy, but not when only one is occupied with work and the other one is free.
Therfore the changed apporach in workload.mo, which should count the absolute working hours in the project for the Consultants. Unfortunately for reason I don't understand ( maybe bug in OpenModelica ), the capacity is not added according to "help3". Remark that protected is removed here for debug reasons